### PR TITLE
Updates Webpack config to correctly load fonts using the extract text plugin (#11)

### DIFF
--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -1,11 +1,11 @@
 @font-face {
 	font-family: 'ArialRoundedMTBold';
-	src: url('../fonts/dialupfonts/ArialRoundedMTBold.eot'); /* IE9 Compat Modes */
-	src: url('../fonts/dialupfonts/ArialRoundedMTBold.eot?#iefix') format('embedded-opentype'),
-	url('../fonts/dialupfonts/ArialRoundedMTBold.woff2') format('woff2'),
-	url('../fonts/dialupfonts/ArialRoundedMTBold.woff') format('woff'),
-	url('../fonts/dialupfonts/ArialRoundedMTBold.ttf')  format('truetype'),
-	url('../fonts/dialupfonts/ArialRoundedMTBold.svg#svgFontName') format('svg'); /* Legacy iOS */
+	src: url('../fonts/ArialRoundedMTBold.eot'); /* IE9 Compat Modes */
+	src: url('../fonts/ArialRoundedMTBold.eot?#iefix') format('embedded-opentype'),
+	url('../fonts/ArialRoundedMTBold.woff2') format('woff2'),
+	url('../fonts/ArialRoundedMTBold.woff') format('woff'),
+	url('../fonts/ArialRoundedMTBold.ttf')  format('truetype'),
+	url('../fonts/ArialRoundedMTBold.svg#svgFontName') format('svg'); /* Legacy iOS */
 }
 
 body {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,10 @@ module.exports = {
             {
                 test: /\.css$/,
                 loader: ExtractTextPlugin.extract("css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]")
+            },
+            {
+                test: /\.(eot|svg|ttf|woff|woff2)$/,
+                loader: ExtractTextPlugin.extract('file?name=src/static/fonts/[name].[ext]')
             }
         ]
     },


### PR DESCRIPTION
Sources:
http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts
https://shellmonger.com/2016/01/22/working-with-fonts-with-webpack/