### PR TITLE
Fix for Issue: Bo Face out of Screen

### DIFF
--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -9,10 +9,14 @@
 }
 
 body {
+	margin: 0;
+	padding: 0;
 	height: 100%;
+	width: 100%;
 	background-color: white;
-    overflow: hidden;
-    -webkit-background-size: cover;
+  overflow: hidden;
+	position: fixed;
+  -webkit-background-size: cover;
 	-moz-background-size: cover;
 	-o-background-size: cover;
 }

--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -9,14 +9,14 @@
 }
 
 body {
-		margin: 0;
-		padding: 0;
-		height: 100%;
-		width: 100%;
-		background-color: white;
-	  overflow: hidden;
-		position: fixed;
-	  -webkit-background-size: cover;
-		-moz-background-size: cover;
-		-o-background-size: cover;
+  margin: 0;
+	padding: 0;
+	height: 100%;
+	width: 100%;
+	background-color: white;
+	overflow: hidden;
+	position: fixed;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
 }

--- a/src/static/css/base.css
+++ b/src/static/css/base.css
@@ -9,14 +9,14 @@
 }
 
 body {
-	margin: 0;
-	padding: 0;
-	height: 100%;
-	width: 100%;
-	background-color: white;
-  overflow: hidden;
-	position: fixed;
-  -webkit-background-size: cover;
-	-moz-background-size: cover;
-	-o-background-size: cover;
+		margin: 0;
+		padding: 0;
+		height: 100%;
+		width: 100%;
+		background-color: white;
+	  overflow: hidden;
+		position: fixed;
+	  -webkit-background-size: cover;
+		-moz-background-size: cover;
+		-o-background-size: cover;
 }


### PR DESCRIPTION
I hate CSS but these constraints kept the p5 canvas the correct size needed for proper BoFace movement. Tested with Desktop version of site and Chrome Inspector mobile