### PR TITLE
I hate CSS but I think I got the logo centering to work on all devices

### DIFF
--- a/src/components/HomePage/styles/HomePage.css
+++ b/src/components/HomePage/styles/HomePage.css
@@ -1,8 +1,8 @@
 .verticalCenter {
-	margin-bottom: 0px;
-	padding-top: 50%;
-	width: 80%;
 	text-align: center;
+	position: absolute;
+	top: 50%;
+	width: 100%;
 	transform: translateY(-50%);
 	-webkit-transform: translateY(-50%);
 	-ms-transform: translateY(-50%);
@@ -14,8 +14,10 @@
 
 @media (max-device-width: 767px) {
     .verticalCenter {
-        transform: translateY(0%);
-        -webkit-transform: translateY(0%);
-        -ms-transform: translateY(0%);
+		top: 50%;
+		width: 100%;
+		transform: translateY(-50%);
+		-webkit-transform: translateY(-50%);
+		-ms-transform: translateY(-50%);
     }
 }


### PR DESCRIPTION
Updated .css of Logo/Link <div> to always be in the center of the page. Tested on Chrome, Safari, and mobile using Chrome DevTools. 

https://css-tricks.com/centering-css-complete-guide/