### PR TITLE
Removed Finance, also a Twitter handle update

### DIFF
--- a/src/components/HomePage/LinksSection.jsx
+++ b/src/components/HomePage/LinksSection.jsx
@@ -22,10 +22,6 @@ const linkItems = [
         path: "https://www.youtube.com/channel/UCLbmvnHClDh_y8imC1wAuDA"
     },
     {
-        text: "FINANCE",
-        path: "http://finance.dialupstuff.com"
-    },
-    {
         text: "PODCAST",
         path: "https://soundcloud.com/dial-up-podcast"
     },

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -97,7 +97,7 @@
 
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:site" content="DIAL UP">
-        <meta name="twitter:creator" content="@DialUpRadio">
+        <meta name="twitter:creator" content="@DialUpStuff">
         <meta name="twitter:title" content="DIAL UP">
         <meta name="twitter:description" content="Summer Magazine Out Now.">
         <meta name="twitter:image:src" content="http://dialupstuff.com/img/favicon/embedImage.png">


### PR DESCRIPTION
Title says it all, pretty much.

- Temporarily removing the Finance link until I can get that developed in React (lowkey excited) and included in the current site codebase.
- Someone updated our Twitter handle for twitter cards from @DialUpRadio to @DialUpStuff