### PR TITLE
Fixed the responsive issues by placing the article header into a flex…

### DIFF
--- a/src/components/PressPage/PressPage.jsx
+++ b/src/components/PressPage/PressPage.jsx
@@ -36,16 +36,21 @@ class PressPage extends React.Component {
           <Row>
             <iframe src="https://player.vimeo.com/video/188082029?color=ffb9a3&portrait=0" width="640" height="469" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
           </Row>
-        </Grid>
-        <h2 className={cx("pressTitle")}> ARTICLES </h2>
+          <Row>
+            <Col xs={12} smOffset={2} sm={8}>
+              <h2 className={cx("pressTitle")}> ARTICLES </h2>
+            </Col>
+          </Row>
+
           <Row className={cx("linkSection")}>
-            <Col xs={4} xsOffset={2}>
+            <Col xs={12} sm={4} smOffset={2}>
               <PressLinks publisher={this.state.press[0].publication} url={this.state.press[0].url} />
             </Col>
-            <Col xs={4}>
+            <Col xs={12} sm={4}>
               <PressLinks publisher={this.state.press[1].publication} url={this.state.press[1].url} />
             </Col>
           </Row>
+        </Grid>
       </div>
 
     )

--- a/src/components/PressPage/styles/PressPage.css
+++ b/src/components/PressPage/styles/PressPage.css
@@ -16,7 +16,7 @@
   color: #F2F2F2;
   margin-bottom: 10px;
   font-size: 2.3em;
-  width: 640px;
+  width: 100%;
   padding-bottom: 5px;
   margin: 0 auto;
 }


### PR DESCRIPTION
…box col and switching out the fixed width that it had. Only issue remaining is that of scrolling on both mobile and desktop, however, this seems to be deeprooted in the base.css file with the default overflow commands.